### PR TITLE
Endpoint campaigns, pass the limit in options

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -9,7 +9,8 @@ Campaigns
     - date
       - start: starting date to fetch the campaigns
       - end: ending date to fetch the campaigns
-    - list: list of the users into DoctorSender (equivalent to user_list) 
+    - list: list of the users into DoctorSender (equivalent to user_list)
+    - limit: maximum number of campaigns to return
  - campaigns/{id}
    - {id} is the ID of the Campaign.
 

--- a/src/Endpoints/Campaigns.php
+++ b/src/Endpoints/Campaigns.php
@@ -79,10 +79,19 @@ class Campaigns extends Endpoint
             $fields = $this->fields;
         }
 
+        /*
+         * Override the limit.
+         */
+        if (isset($options['limit'])) {
+            $limit = $options['limit'];
+        } else {
+            $limit = $this->limit;
+        }
+
         return $this->client->webservice(
-                'dsCampaignGetAll',
-                array($sqlWhere, $fields, $this->withStatistics, $this->limit)
-            );
+            'dsCampaignGetAll',
+            array($sqlWhere, $fields, $this->withStatistics, $limit)
+        );
     }
 
     /**
@@ -107,8 +116,8 @@ class Campaigns extends Endpoint
         }
 
         return $this->client->webservice(
-                'dsCampaignGet',
-                array($idCampaign, $fields, $this->withStatistics)
-            );
+            'dsCampaignGet',
+            array($idCampaign, $fields, $this->withStatistics)
+        );
     }
 }


### PR DESCRIPTION
The limit can be passed into the options of the listing of campaigns.

The documentation has been modified.
This closes #5