### PR TITLE
Moved PHPUnit to dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ php:
   - '5.6'
   - '7.0'
   - '7.1'
-  - nightly
+  - '7.2'
+  - '7.3'
 
 script:
   - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,9 @@
   },
   "require": {
     "php": "^5.6|^7.0",
-    "phpunit/phpunit": "^5.7|^6.5",
     "psr/log": "^1.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^5.7|^6.5"
   }
 }

--- a/src/Endpoints/Users.php
+++ b/src/Endpoints/Users.php
@@ -41,7 +41,8 @@ class Users extends Endpoint
 
         return $this->client->webservice(
             'dsUsersListAdd',
-            array($listName, $user, $isTestList)
+            array($listName, $user, $isTestList),
+            []
         );
     }
 }


### PR DESCRIPTION
It should never have been in required.
PHPUnit 5 and 6 are not supported anymore.